### PR TITLE
Documenting the MWI_HOST variable, whose default changed in v0.3.0

### DIFF
--- a/Advanced-Usage.md
+++ b/Advanced-Usage.md
@@ -18,6 +18,7 @@ The following table describes all the environment variables that you can set to 
 | **MLM_LICENSE_FILE** | string | `"1234@111.22.333.444"` | When you want to use either a license file or a network license manager to license MATLAB, specify this variable.</br> For example, specify the location of the network license manager to be `123@hostname`.|                                                                         
 | **MWI_BASE_URL** | string | `"/matlab"` | Set to control the base URL of the app. MWI_BASE_URL should start with `/` or be `empty`. |
 | **MWI_APP_PORT** | integer | `8080` | Specify the port for the HTTP server to listen on. |
+| **MWI_APP_HOST** | string | `127.0.0.1` | Specify the host interface for the HTTP server to listen on. By default, it only allows for connections from the host itself. For allowing connections from everywhere, use "0.0.0.0" instead. |
 | **MWI_LOG_LEVEL** | string | `"CRITICAL"` | Specify the Python log level to be one of the following `NOTSET`, `DEBUG`, `INFO`, `WARN`, `ERROR`, or `CRITICAL`. For more information on Python log levels, see [Logging Levels](https://docs.python.org/3/library/logging.html#logging-levels) .<br />The default value is `INFO`. |
 | **MWI_LOG_FILE** | string | `"/tmp/logs.txt"` | Specify the full path to the file where you want debug logs from this integration to be written. |
 | **MWI_ENABLE_WEB_LOGGING** | string | `"True"` | Set this value to `"True"` to see additional web server logs. |

--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -32,6 +32,8 @@ RUN python3 -m pip install matlab-proxy
 # MATLAB should then become accessible on http://localhost:8888/matlab/index.html
 ENV MWI_APP_PORT=8888
 ENV MWI_BASE_URL="/matlab"
+# Uncomment the following line if you want matlab to be a accessible from other ips than localhost
+# ENV MWI_APP_HOST="0.0.0.0"
 
 USER matlab
 ENTRYPOINT ["matlab-proxy-app"]


### PR DESCRIPTION
I propose some more documentation on this environment variable, because : 
- it was not documented at all
- its default changed from "" (all interfaces) to "127.0.0.1", which broke any connection from the outside (for instance, a container with an exposed 8888 port was rejecting connections).

Another solution would be to put the default back to 0.0.0.0. But having the default value being the more constrained/secured seems right to me.

