### PR TITLE
remove dependency on importlib-metadata and improtlib-resources

### DIFF
--- a/matlab_proxy/app.py
+++ b/matlab_proxy/app.py
@@ -493,7 +493,7 @@ def make_static_route_table(app):
     Returns:
         Dict: Containing information about the static files and header information.
     """
-    import importlib_resources
+    import importlib.resources
 
     from matlab_proxy import gui
     from matlab_proxy.gui import static
@@ -510,9 +510,9 @@ def make_static_route_table(app):
         (gui.static.js.__name__, "/static/js"),
         (gui.static.media.__name__, "/static/media"),
     ]:
-        for entry in importlib_resources.files(mod).iterdir():
+        for entry in importlib.resources.files(mod).iterdir():
             name = entry.name
-            if not importlib_resources.files(mod).joinpath(name).is_dir():
+            if not importlib.resources.files(mod).joinpath(name).is_dir():
                 if name != "__init__.py":
                     # Special case for manifest.json
                     if "manifest.json" in name:

--- a/matlab_proxy/util/mwi/validators.py
+++ b/matlab_proxy/util/mwi/validators.py
@@ -214,9 +214,9 @@ def __get_configs():
         Dict: Contains all the values present in 'matlab_web_desktop_configs' entry_point from all the packages
         installed in the current environment.
     """
-    import importlib_metadata
+    import importlib.metadata
 
-    matlab_proxy_eps = importlib_metadata.entry_points(
+    matlab_proxy_eps = importlib.metadata.entry_points(
         group=matlab_proxy.get_entrypoint_name()
     )
     configs = {}

--- a/setup.py
+++ b/setup.py
@@ -66,8 +66,6 @@ TESTS_REQUIRES = [
 INSTALL_REQUIRES = [
     "aiohttp>=3.7.4",
     "aiohttp_session[secure]",
-    "importlib-metadata",
-    "importlib-resources",
     "psutil",
     "watchdog",
     "requests",


### PR DESCRIPTION
Those packages have been integrated into Python 3.8 and 3.7 respectively. There is no need to install those. 